### PR TITLE
Add the support for evaluating embedded reStructured Text

### DIFF
--- a/recommonmark/parser.py
+++ b/recommonmark/parser.py
@@ -124,6 +124,13 @@ class CommonMarkParser(parsers.Parser):
 
     def code(self, language, text):
         classes = ['code', 'highlight']
+
+        # embedded rst in codeblocks
+        if language == 'eval_rst':
+            rst_parser = parsers.rst.Parser()
+            rst_parser.parse(text, self.current_node.document)
+            return
+
         if language:
             classes.append(language)
 


### PR DESCRIPTION
allow evaluating rst blocks inside markdown when a codeblock is marked by ```eval_rst```, this enables the usage of the rst syntax for structured commands(toctree) inside the remarkdown.